### PR TITLE
feat: return global data retention in config api

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
             file_ext: .tar.gz
           - arch: x86_64-unknown-linux-musl
             os: ubuntu-2004-8-cores
-            features: ""
+            features: "--features mimalloc"
             file_name: openobserve-${{ github.ref_name }}-linux-amd64-musl
             file_ext: .tar.gz
           - arch: aarch64-unknown-linux-gnu

--- a/src/handler/http/request/status/mod.rs
+++ b/src/handler/http/request/status/mod.rs
@@ -46,6 +46,7 @@ struct ConfigResponse<'a> {
     sql_base64_enabled: bool,
     timestamp_column: String,
     syslog_enabled: bool,
+    data_retention_days: i64,
 }
 
 /** Healthz */
@@ -81,6 +82,7 @@ pub async fn zo_config() -> Result<HttpResponse, Error> {
         sql_base64_enabled: CONFIG.common.ui_sql_base64_enabled,
         timestamp_column: CONFIG.common.column_timestamp.clone(),
         syslog_enabled: *SYSLOG_ENABLED.read(),
+        data_retention_days: CONFIG.compact.data_retention_days,
     }))
 }
 

--- a/src/infra/config.rs
+++ b/src/infra/config.rs
@@ -242,8 +242,6 @@ pub struct Compact {
     pub interval: u64,
     #[env_config(name = "ZO_COMPACT_MAX_FILE_SIZE", default = 256)] // MB
     pub max_file_size: u64,
-    #[env_config(name = "ZO_COMPACT_DATA_RETENTION_ENABLED", default = false)]
-    pub data_retention_enabled: bool,
     #[env_config(name = "ZO_COMPACT_DATA_RETENTION_DAYS", default = 0)] // in days
     pub data_retention_days: i64,
 }

--- a/src/service/compact/mod.rs
+++ b/src/service/compact/mod.rs
@@ -31,7 +31,7 @@ pub(crate) static QUEUE_LOCKER: Lazy<Arc<Mutex<bool>>> =
 /// compactor delete run steps:
 pub async fn run_delete() -> Result<(), anyhow::Error> {
     // check data lifecyle date
-    if CONFIG.compact.data_retention_enabled {
+    if CONFIG.compact.data_retention_days > 0 {
         let now = chrono::Utc::now();
         let date = now - chrono::Duration::days(CONFIG.compact.data_retention_days);
         let data_lifecycle_end = date.format("%Y-%m-%d").to_string();

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -18,14 +18,14 @@ mod tests {
     use bytes::{Bytes, BytesMut};
     use chrono::Utc;
     use core::time;
+    use openobserve::{
+        common::json,
+        handler::http::router::*,
+        infra::{config::CONFIG, db::default},
+        meta::dashboards::{Dashboard, Dashboards},
+    };
     use prost::Message;
-    use std::sync::Once;
-    use std::{env, fs, str, thread};
-    use openobserve::common::json;
-    use openobserve::handler::http::router::*;
-    use openobserve::infra::config::CONFIG;
-    use openobserve::infra::db::default;
-    use openobserve::meta::dashboards::{Dashboard, Dashboards};
+    use std::{env, fs, str, sync::Once, thread};
 
     static START: Once = Once::new();
 


### PR DESCRIPTION
impl #697 

- [x]  setting API for stream 
- [x]  export global data retention in config API

## ENV changed:

| item | default value | desc |
|--|--|--|
| ZO_DATA_LIFECYCLE* | -- | deprecate |
| ZO_COMPACT_DATA_RETENTION * | -- | deprecate |
| ZO_COMPACT_DATA_RETENTION_DAYS | 0 | global data retention days, zero for disable, eg: set to 15, means every stream keep 15 days|

## Setting API:

POST `/api/{org_id}/{stream_name}/settings`

```json
{
    "partition_keys": [],
    "full_text_search_keys": [],
    "data_retention": 0,
}
```

use API set data retention for stream.

## Config API:

The key in config API is:

```
data_retention_days
```

